### PR TITLE
allow dependency version to be missing

### DIFF
--- a/download_esm/cli.py
+++ b/download_esm/cli.py
@@ -70,7 +70,8 @@ def extract_original_file(content):
 
 
 def simplify_path(path):
-    package_name, version = path.split("/npm/")[1].rsplit("@", 1)
+    package_name, *version = path.split("/npm/")[1].rsplit("@", 1)
+    version = "".join(version)
     version = version.split("/")[0]
     version = version.replace(".", "-")
     simplified_name = f"{package_name}-{version}.js"


### PR DESCRIPTION
Module versions are sometimes not provided, e.g. here:

`download-esm https://cdn.jsdelivr.net/npm/d3fc@15.2.6/+esm`